### PR TITLE
feat: add linear trend line with r2 and y-axis formatting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -118,19 +118,26 @@ const KPI_DEFS = {
   CPH: { name: 'CPH', unit: 'cases/hour', hasGoal: true, goal: PAYLOAD.goals.CPH },
 };
 
-// Calculate a simple moving average for the provided points. The moving
-// average smooths out short–term fluctuations and is controlled by the
-// window size `n`. It returns an array of objects with the same date
-// formatting as the chart expects.
-function movingAverage(points, n = 3) {
-  const out = [];
-  for (let i = 0; i < points.length; i++) {
-    const start = Math.max(0, i - n + 1);
-    const slice = points.slice(start, i + 1);
-    const avg = slice.reduce((s, p) => s + p.value, 0) / slice.length;
-    out.push({ date: slice[slice.length - 1].date, value: avg });
-  }
-  return out;
+// Perform a simple linear regression over the provided points (using the
+// index as the independent variable). Returns the slope, intercept and the
+// coefficient of determination (R²) so the caller can compute fitted values
+// without losing the original data points.
+function linearRegression(points) {
+  const n = points.length;
+  if (n === 0) return { slope: 0, intercept: 0, r2: 0 };
+  const xVals = points.map((_, i) => i);
+  const yVals = points.map((p) => p.value);
+  const sumX = xVals.reduce((s, v) => s + v, 0);
+  const sumY = yVals.reduce((s, v) => s + v, 0);
+  const sumXY = xVals.reduce((s, v, i) => s + v * yVals[i], 0);
+  const sumXX = xVals.reduce((s, v) => s + v * v, 0);
+  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+  const meanY = sumY / n;
+  const ssTot = yVals.reduce((s, v) => s + (v - meanY) ** 2, 0);
+  const ssRes = xVals.reduce((s, v, i) => s + (yVals[i] - (intercept + slope * v)) ** 2, 0);
+  const r2 = ssTot === 0 ? 0 : 1 - ssRes / ssTot;
+  return { slope, intercept, r2 };
 }
 
 // Return the index of the maximum value in an array of points. If the array
@@ -181,8 +188,20 @@ function MainChart({ kpiKey, onPointClick, selectedIndex, showTrend }) {
     const padding = range === 0 ? 1 : range * 0.05;
     return [Math.max(0, min - padding), max + padding];
   }, [data]);
-  // Compute the trend line (moving average) if requested.
-  const trend = useMemo(() => (showTrend ? movingAverage(data, 3) : []), [data, showTrend]);
+  // Determine if values should be shown as percentages (max ≤ 1).
+  const isPercent = useMemo(() => {
+    if (!data.length) return false;
+    const maxVal = Math.max(...data.map((d) => Math.abs(d.value)));
+    return maxVal <= 1;
+  }, [data]);
+  // Compute the linear regression parameters and R² if requested.
+  const regression = useMemo(() => (showTrend ? linearRegression(data) : null), [data, showTrend]);
+  // Merge the regression trend into the chart data so the chart can render
+  // both the original series and the fitted values without losing points.
+  const chartData = useMemo(() => {
+    if (!showTrend || !regression) return data;
+    return data.map((d, i) => ({ ...d, trend: regression.intercept + regression.slope * i }));
+  }, [data, regression, showTrend]);
   // Determine the selected ISO date for the reference area.
   const selectedDate = data[selectedIndex]?.date;
   // Handle click events on the chart. Recharts provides the activeLabel
@@ -201,7 +220,7 @@ function MainChart({ kpiKey, onPointClick, selectedIndex, showTrend }) {
       <div className="h-[420px] p-4">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart
-            data={data}
+            data={chartData}
             margin={{ top: 16, right: 24, bottom: 40, left: 0 }}
             onClick={handleClick}
           >
@@ -228,6 +247,7 @@ function MainChart({ kpiKey, onPointClick, selectedIndex, showTrend }) {
             <YAxis
               domain={[yMin, yMax]}
               tick={{ fill: '#004984', fontSize: 12 }}
+              tickFormatter={(v) => (isPercent ? `${(v * 100).toFixed(2)}%` : v.toFixed(2))}
               tickMargin={8}
               label={{
                 value: kpi.name,
@@ -239,7 +259,10 @@ function MainChart({ kpiKey, onPointClick, selectedIndex, showTrend }) {
             <Tooltip
               contentStyle={{ backgroundColor: '#FFFFFF', border: '1px solid #D4D2CA', borderRadius: 10 }}
               labelStyle={{ color: '#004984' }}
-              formatter={(value) => [Number(value).toFixed(2), kpi.unit]}
+              formatter={(value) => [
+                isPercent ? `${(Number(value) * 100).toFixed(2)}%` : Number(value).toFixed(2),
+                kpi.unit,
+              ]}
             />
             {/* Goal line, if applicable */}
             {kpi.hasGoal && (
@@ -268,16 +291,16 @@ function MainChart({ kpiKey, onPointClick, selectedIndex, showTrend }) {
               dot={{ r: 4, strokeWidth: 2, stroke: '#FFFFFF', fill: 'url(#lineGradient)', cursor: 'pointer' }}
               activeDot={{ r: 6, strokeWidth: 2, stroke: '#FFFFFF', fill: 'url(#lineGradient)' }}
             />
-            {/* Trend line (moving average) */}
-            {showTrend && trend.length > 0 && (
+            {/* Trend line (linear regression) */}
+            {showTrend && regression && (
               <Line
-                data={trend}
-                type="monotone"
-                dataKey="value"
+                type="linear"
+                dataKey="trend"
                 stroke="#4498F2"
                 strokeDasharray="6 6"
                 strokeWidth={2}
                 dot={false}
+                isAnimationActive={false}
               />
             )}
             {/* Gradient definition for the main line */}
@@ -296,6 +319,14 @@ function MainChart({ kpiKey, onPointClick, selectedIndex, showTrend }) {
       >
         {kpi.name} for LOB
       </div>
+      {showTrend && regression && (
+        <div
+          className="absolute top-2 right-2 text-xs font-bold"
+          style={{ color: '#3047B0' }}
+        >
+          R²: {regression.r2.toFixed(2)}
+        </div>
+      )}
     </div>
   );
 }
@@ -320,6 +351,11 @@ function SecondaryPanel({ kpiKey, weekISO }) {
     return arr.slice().sort((a, b) => a.date.localeCompare(b.date));
   }, [kpiKey, weekISO]);
   const hasDaily = dailyArr.length > 0;
+  const isPercent = useMemo(() => {
+    if (!dailyArr.length) return false;
+    const maxVal = Math.max(...dailyArr.map((d) => Math.abs(d.value)));
+    return maxVal <= 1;
+  }, [dailyArr]);
   return (
     <div className="h-full w-full p-2">
       <div className="mb-2 flex items-center justify-between">
@@ -368,12 +404,16 @@ function SecondaryPanel({ kpiKey, weekISO }) {
                 />
                 <YAxis
                   tick={{ fill: '#004984', fontSize: 10 }}
+                  tickFormatter={(v) => (isPercent ? `${(v * 100).toFixed(2)}%` : v.toFixed(2))}
                   tickMargin={6}
                 />
                 <Tooltip
                   contentStyle={{ backgroundColor: '#FFFFFF', border: '1px solid #D4D2CA', borderRadius: 10 }}
                   labelStyle={{ color: '#004984', fontSize: 10 }}
-                  formatter={(value) => [Number(value).toFixed(2), kpi.unit]}
+                  formatter={(value) => [
+                    isPercent ? `${(Number(value) * 100).toFixed(2)}%` : Number(value).toFixed(2),
+                    kpi.unit,
+                  ]}
                 />
                 <Line
                   type="monotone"


### PR DESCRIPTION
## Summary
- compute linear regression parameters and merge trend into chart data
- overlay trend line without dropping intermediate points
- format y-axis values as percentages or decimals with two digits in charts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: You installed esbuild for another platform than the one you're currently using.)*


------
https://chatgpt.com/codex/tasks/task_e_689d61d7428883309b6e9eef02125045